### PR TITLE
Adding a .gitignore file at the top level to ignore IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# JetBrains IDEs (CLion, IntelliJ, and PyCharm)
+.idea
+
+# CLIion CMake builds
+cmake-build-debug
+
+


### PR DESCRIPTION
Currently it ignores JetBrains IDE project directories for CLion, IntelliJ, and PyCharm
as well as CMake build directories from CLion.