### PR TITLE
Update .gitignore to ignore common python artifacts like pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@
 # CLIion CMake builds
 cmake-build-debug
 
-
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
Copied from https://github.com/github/gitignore/blob/master/Python.gitignore