### PR TITLE
Resolve Issue #7 in binary_tree_to_string method

### DIFF
--- a/epi_judge_python/test_framework/binary_tree_utils.py
+++ b/epi_judge_python/test_framework/binary_tree_utils.py
@@ -1,6 +1,6 @@
 # @library
 import sys
-
+import collections
 sys.setrecursionlimit(15500)
 
 
@@ -64,14 +64,14 @@ def must_find_node(tree, val):
 
 def binary_tree_to_string(node):
     result = '['
-    q = [node]
+    q = collections.deque([node])
     visited = set()
 
     null_nodes_pending = 0
     first = True
 
     while q:
-        n = q.pop()
+        n = q.popleft()
         if id(n) in visited:  # TODO: Denote cycles
             continue
         if n:
@@ -85,8 +85,8 @@ def binary_tree_to_string(node):
             result += '"{}"'.format(n.data)
 
             visited.add(id(n))
-            q.append(node.left)
-            q.append(node.right)
+            q.append(n.left)
+            q.append(n.right)
         else:
             null_nodes_pending += 1
 


### PR DESCRIPTION
Using collections.deque to implement queue used for BFS in binary_tree_to_string_method. 
Previously it was using a simple Python List as a stack which is incorrect for this purpose. 
