### PR TITLE
 Fix `TypeError` from being raised during creation of `RuntimeError`

### DIFF
--- a/epi_judge_python/test_framework/test_utils_deserialization.py
+++ b/epi_judge_python/test_framework/test_utils_deserialization.py
@@ -144,8 +144,9 @@ def get_object_cast_for_type(typename):
 
         def tuple_parse(data):
             if len(data) != len(parsers):
-                raise RuntimeError("Tuple parser: expected " + str(
-                    len(parsers)) + " values, got " + len(data))
+                raise RuntimeError(
+                    "Tuple parser: expected {} values, got {}".format(
+                        len(parsers), len(data)))
             return tuple([p(x) for (p, x) in zip(parsers, data)])
 
         return tuple_parse


### PR DESCRIPTION
I was taking a break from reading this awesome book (EPI in Python) and noticed something while looking through the Python `test_framework` code.

https://github.com/adnanaziz/EPIJudge/blob/238ccde216fa4a8616a8dccf74b3ba76d343adf3/epi_judge_python/test_framework/test_utils_deserialization.py#L147

```python
>>> parsers = [1, 2, 3]
>>> data = [3, 4, 5, 6, 7]

# Issue
>>> raise RuntimeError("Tuple parser: expected " + str(len(parsers)) + " values, got " + len(data))
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: must be str, not int

# Cause
>>> " values, got " + len(data)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: must be str, not int
>>> "" + 1
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: must be str, not int

# Solution
>>> raise RuntimeError("Tuple parser: expected {} values, got {}".format(len(parsers), len(data)))
Traceback (most recent call last):
  File "<input>", line 1, in <module>
RuntimeError: Tuple parser: expected 3 values, got 5
```