### PR TITLE
Removes extraneous max() operation from longest_nondecreasing_subsequence_length.py

### DIFF
--- a/epi_judge_python_solutions/longest_nondecreasing_subsequence.py
+++ b/epi_judge_python_solutions/longest_nondecreasing_subsequence.py
@@ -3,9 +3,8 @@ def longest_nondecreasing_subsequence_length(A):
     # of A[:i + 1].
     max_length = [1] * len(A)
     for i in range(1, len(A)):
-        max_length[i] = max(1 + max(
-            (max_length[j] for j in range(i) if A[i] >= A[j]), default=0),
-                            max_length[i])
+        max_length[i] = 1 + max((max_length[j] for j in range(i)
+                                if A[i] >= A[j]), default=0)
     return max(max_length)
 
 


### PR DESCRIPTION
This commit removes an extraneous `max()` operation that attempts to compare the term `max_length[i]` (initialized to `1`) with a value that is always going to be greater than `1`.

Tests bundled in the package passed succesfully:

Test PASSED (200/200) [  95 us]
Average running time:  331 us
Median running time:    68 us
*** You've passed ALL tests. Congratulations! ***