### PR TITLE
Avoid unused parameter error

### DIFF
--- a/epi_judge_cpp/test_framework/generic_test.h
+++ b/epi_judge_cpp/test_framework/generic_test.h
@@ -91,7 +91,7 @@ TestResult RunTests(GenericTestHandler<Function, Comparator>& handler,
     } catch (TimeoutException& e) {
       result = TIMEOUT;
       test_timer = e.GetTimer();
-    } catch (std::runtime_error& e) {
+    } catch (std::runtime_error&) {
       throw;
     } catch (std::exception& e) {
       result = UNKNOWN_EXCEPTION;


### PR DESCRIPTION
Visual Studio cl.exe gives a warning on unused named catch arguments