### PR TITLE
Should use `BinaryTree` as it has parent field

### DIFF
--- a/epi_judge_java/epi/TreeInorder.java
+++ b/epi_judge_java/epi/TreeInorder.java
@@ -5,7 +5,7 @@ import java.util.List;
 public class TreeInorder {
   @EpiTest(testDataFile = "tree_inorder.tsv")
 
-  public static List<Integer> inorderTraversal(BinaryTreeNode<Integer> tree) {
+  public static List<Integer> inorderTraversal(BinaryTree<Integer> tree) {
     // TODO - you fill in here.
     return null;
   }


### PR DESCRIPTION
According to the description of 9.11, we are asked to implement inorder traversal without recursion, but assume nodes have *parent fields*. Class `BinaryTreeNode` doesn't have parent field.