### PR TITLE
Fixed compilation errors

### DIFF
--- a/epi_judge_java/epi/test_framework/GenericTestHandler.java
+++ b/epi_judge_java/epi/test_framework/GenericTestHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.Arrays;
 
 /**
  * The central class in generic test runner framework.
@@ -64,7 +65,7 @@ public class GenericTestHandler {
     this.func = func;
     this.comparator = comparator;
     hasExecutorHook = false;
-    paramTypes = List.of(func.getGenericParameterTypes());
+    paramTypes = Arrays.asList(func.getGenericParameterTypes());
 
     if (paramTypes.size() >= 1 &&
         paramTypes.get(0).equals(TimedExecutor.class)) {

--- a/epi_judge_java/epi/test_framework/TestUtils.java
+++ b/epi_judge_java/epi/test_framework/TestUtils.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import java.util.Arrays;
 
 public class TestUtils {
   public static List<List<String>> splitTsvFile(Path tsvFile) {
@@ -27,7 +28,8 @@ public class TestUtils {
 
     List<List<String>> result = new ArrayList<>();
     for (String line : asList) {
-      result.add(List.of(line.split(FIELD_DELIM)));
+      
+      result.add(Arrays.asList(line.split(FIELD_DELIM)));
     }
     return result;
   }

--- a/epi_judge_java/epi/test_framework/serialization_traits/TraitsFactory.java
+++ b/epi_judge_java/epi/test_framework/serialization_traits/TraitsFactory.java
@@ -18,7 +18,7 @@ public class TraitsFactory {
   private static final Map<Type, SerializationTraits> PRIMITIVE_TYPES_MAPPING;
 
   static {
-    PRIMITIVE_TYPES_MAPPING = new HashMap<>() {
+    PRIMITIVE_TYPES_MAPPING = new HashMap<Type, SerializationTraits>() {
       {
         put(String.class, new StringTraits());
         put(Integer.class, new IntegerTraits());


### PR DESCRIPTION
The epijudge as it would not work with the latest eclipse on mac os. I have fixed the errors found.

one of the errors: 
```./epi/test_framework/GenericTestHandler.java:67: error: cannot find symbol
    paramTypes = List.of(func.getGenericParameterTypes());
                     ^
  symbol:   method of(Type[])
  location: interface List
1 error
make: *** [java_build/epi/test_framework/GenericTestHandler.class] Error 1