### PR TITLE
Update two_sum.py for same index sum bug

### DIFF
--- a/epi_judge_python_solutions/two_sum.py
+++ b/epi_judge_python_solutions/two_sum.py
@@ -5,7 +5,7 @@ def has_two_sum(A, t):
 
     i, j = 0, len(A) - 1
 
-    while i <= j:
+    while i < j:
         if A[i] + A[j] == t:
             return True
         elif A[i] + A[j] < t:


### PR DESCRIPTION
has_two_sum([1, 2, 3], 6) returns True, even though it should be False. In the while loop, i should not be able to equal j to ensure that the two indices whose elements add up to the sum are distinct. It seems this error is also in the test cases, where the tester expects True for has_two_sum([-2, -1, 1, 4], 8) although this should also be False. Is the problem defined differently than what I understand, and the same index can be used twice?