### PR TITLE
Java Powerset: Cleaner way of finding index of lowest set bit

### DIFF
--- a/epi_judge_java_solutions/epi/PowerSet.java
+++ b/epi_judge_java_solutions/epi/PowerSet.java
@@ -21,8 +21,7 @@ public class PowerSet {
       int bitArray = intForSubset;
       List<Integer> subset = new ArrayList<>();
       while (bitArray != 0) {
-        subset.add(inputSet.get(
-            (int)(Math.log(bitArray & ~(bitArray - 1)) / Math.log(2))));
+        subset.add(inputSet.get(Integer.numberOfTrailingZeros(bitArray)));
         bitArray &= bitArray - 1;
       }
       powerSet.add(subset);


### PR DESCRIPTION
Hi,
Not sure if this is the best way of suggesting a solution improvement but here goes :)

Instead of explicitly calculating a Log base 2 on the lowest set bit, use the builtin `Integer.numberOfTrailingZeros`. This is  a cleaner and (IMO) more intuitive way of calculating the index of the lowest set bit, since its easy to reason about (eg if there is 1 trailing zero, the lowest set bit is at index 1 etc). It is also faster, and although that isn't quite as relevant here, is definitely best practice if this sort of thing was ever actually needed.

This change would require some rewrite of the paragraph beforehand