### PR TITLE
Add stack trace to test failure output

### DIFF
--- a/epi_judge_python/test_framework/generic_test.py
+++ b/epi_judge_python/test_framework/generic_test.py
@@ -2,6 +2,7 @@
 import json
 import os
 import sys
+import traceback
 
 from test_framework.generic_test_handler import GenericTestHandler
 from test_framework.platform import set_output_opts
@@ -87,7 +88,8 @@ def run_tests(handler, config, res_printer):
         except Exception as exc:
             result = TestResult.UNKNOWN_EXCEPTION
             test_failure = TestFailure(exc.__class__.__name__).with_property(
-                PropertyName.EXCEPTION_MESSAGE, str(exc))
+                PropertyName.EXCEPTION_MESSAGE, str(exc)).with_property(
+                PropertyName.EXCEPTION_TRACEBACK, traceback.format_exc())
 
         print_test_info(result, test_nr, total_tests,
                         test_failure.get_description(), test_timer)

--- a/epi_judge_python/test_framework/test_failure.py
+++ b/epi_judge_python/test_framework/test_failure.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 
 class PropertyName(Enum):
     EXCEPTION_MESSAGE = auto()  # message of unhandled exception
+    EXCEPTION_TRACEBACK = auto()  # Full stack trace of the unhandled exception
     EXPLANATION = auto()  # explanation from TSV file
     COMMAND = auto(
     )  # last command, that caused the error, in API-testing programs


### PR DESCRIPTION
It's frustrating to find the source of an unhandled exception in my code without having at least the line number where the problem happens.

With a full traceback debugging is made much easier.

PS: Thank you for the great book and this judge. I'm learning a lot about how to write good Python solutions!