### PR TITLE
Update TraitsFactory.java HashMap declaration

### DIFF
--- a/epi_judge_java/epi/test_framework/serialization_traits/TraitsFactory.java
+++ b/epi_judge_java/epi/test_framework/serialization_traits/TraitsFactory.java
@@ -18,7 +18,7 @@ public class TraitsFactory {
   private static final Map<Type, SerializationTraits> PRIMITIVE_TYPES_MAPPING;
 
   static {
-    PRIMITIVE_TYPES_MAPPING = new HashMap<>() {
+    PRIMITIVE_TYPES_MAPPING = new HashMap<Type, SerializationTraits>() {
       {
         put(String.class, new StringTraits());
         put(Integer.class, new IntegerTraits());


### PR DESCRIPTION
line 21, it wouldn’t run with just HashMap<>.

changing to PRIMITIVE_TYPES_MAPPING = new HashMap<Type, SerializationTraits>() solves the issue.