### PR TITLE
fix build issue with java8.

### DIFF
--- a/epi_judge_java/epi/DutchNationalFlag.java
+++ b/epi_judge_java/epi/DutchNationalFlag.java
@@ -4,13 +4,33 @@ import epi.test_framework.GenericTest;
 import epi.test_framework.TestFailure;
 import epi.test_framework.TimedExecutor;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 public class DutchNationalFlag {
   public enum Color { RED, WHITE, BLUE }
 
   public static void dutchFlagPartition(int pivotIndex, List<Color> A) {
     // TODO - you fill in here.
-    return;
+    Color pivot = A.get(pivotIndex);
+    /**
+     * Keep the following invariants during partitioning:
+     * bottom group: A.subList(0, smaller).
+     * middle group: A.subList(smaller, equal).
+     * unclassified group: A.subList(equal, larger).
+     * top group: A.subList(larger, A.size()).
+     */
+    int smaller = 0, equal = 0, larger = A.size();
+    // Keep iterating as long as there is an unclassified element.
+    while (equal < larger) {
+      // A.get(equal) is the incoming unclassified element.
+      if (A.get(equal).ordinal() < pivot.ordinal()) {
+        Collections.swap(A, smaller++, equal++);
+      } else if (A.get(equal).ordinal() == pivot.ordinal()) {
+        ++equal;
+      } else { // A.get(equal) > pivot.
+        Collections.swap(A, equal, --larger);
+      }
+    }
   }
   @EpiTest(testDataFile = "dutch_national_flag.tsv")
   public static void dutchFlagPartitionWrapper(TimedExecutor executor,

--- a/epi_judge_java/epi/test_framework/GenericTestHandler.java
+++ b/epi_judge_java/epi/test_framework/GenericTestHandler.java
@@ -64,7 +64,7 @@ public class GenericTestHandler {
     this.func = func;
     this.comparator = comparator;
     hasExecutorHook = false;
-    paramTypes = List.of(func.getGenericParameterTypes());
+    paramTypes = Arrays.asList(func.getGenericParameterTypes());
 
     if (paramTypes.size() >= 1 &&
         paramTypes.get(0).equals(TimedExecutor.class)) {
@@ -82,7 +82,7 @@ public class GenericTestHandler {
     paramNames = Arrays.stream(func.getParameters())
                      .map(Parameter::getName)
                      .collect(Collectors.toList());
-    if (hasExecutorHook) {
+  if (hasExecutorHook) {
       paramNames.remove(0);
     }
 

--- a/epi_judge_java/epi/test_framework/TestUtils.java
+++ b/epi_judge_java/epi/test_framework/TestUtils.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -27,7 +28,7 @@ public class TestUtils {
 
     List<List<String>> result = new ArrayList<>();
     for (String line : asList) {
-      result.add(List.of(line.split(FIELD_DELIM)));
+      result.add(Arrays.asList(line.split(FIELD_DELIM)));
     }
     return result;
   }

--- a/epi_judge_java/epi/test_framework/serialization_traits/TraitsFactory.java
+++ b/epi_judge_java/epi/test_framework/serialization_traits/TraitsFactory.java
@@ -18,7 +18,7 @@ public class TraitsFactory {
   private static final Map<Type, SerializationTraits> PRIMITIVE_TYPES_MAPPING;
 
   static {
-    PRIMITIVE_TYPES_MAPPING = new HashMap<>() {
+    PRIMITIVE_TYPES_MAPPING = new HashMap<Type, SerializationTraits>() {
       {
         put(String.class, new StringTraits());
         put(Integer.class, new IntegerTraits());


### PR DESCRIPTION
I was having trouble building the test cases for Java8 on Mac. Not sure if its a common problem. Lists.of seems to be a java 9 feature. I have replaced it with Arrays.asList. The only difference is that one returns immutable List the other one does not. 