### PR TITLE
String Transformability: Iterate using char instead of int

### DIFF
--- a/epi_judge_cpp_solutions/string_transformability.cc
+++ b/epi_judge_cpp_solutions/string_transformability.cc
@@ -28,8 +28,8 @@ int TransformString(unordered_set<string> D, const string& s, const string& t) {
     // Tries all possible transformations of f.candidate_string.
     string str = f.candidate_string;
     for (int i = 0; i < size(str); ++i) {
-      for (int c = 0; c < 26; ++c) {  // Iterates through 'a' ~ 'z'.
-        str[i] = 'a' + c;
+      for (char c = 'a'; c <= 'z'; ++c) {  // Iterates through 'a' ~ 'z'.
+        str[i] = c;
         if (auto it = D.find(str); it != end(D)) {
           D.erase(it);
           q.emplace(StringWithDistance{str, f.distance + 1});


### PR DESCRIPTION
In my opinion, this improves readability by directly iterating over the characters in the alphabet.
Furthermore, it improves performance by saving the `+` in the line that was previously `str[i] = 'a' + c`

Overall, it's a minor improvement. Either way, I thought you might like it so decided to suggest it.