### PR TITLE
Support for python3 prior to version 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The IntelliJ Integrated Development environments described above are best-in-cla
   - Java     
     - **Java** 9
   - Python
-    - **Python** 3.6
+    - **Python** 3.3 to 3.5 (using [aenum](https://pypi.org/project/aenum/)) or 3.6 (using the [enum](https://docs.python.org/3/library/enum.html) built in to the stdlib)
    
 
 - What compilers are supported for solutions?
@@ -112,7 +112,7 @@ The IntelliJ Integrated Development environments described above are best-in-cla
     - Java     
       - **Java** 9
     - Python
-      - **Python** 3.6 
+      - **Python** 3.3 to 3.5 (using [aenum](https://pypi.org/project/aenum/)) or 3.6 (using the [enum](https://docs.python.org/3/library/enum.html) built in to the stdlib)
 
 Let us know if you managed to compile with an older version.
 

--- a/epi_judge_python/test_framework/console_color.py
+++ b/epi_judge_python/test_framework/console_color.py
@@ -1,6 +1,6 @@
 
 import sys
-from enum import Enum, auto
+from aenum import Enum, auto
 
 from test_framework import platform
 

--- a/epi_judge_python/test_framework/test_failure.py
+++ b/epi_judge_python/test_framework/test_failure.py
@@ -1,5 +1,5 @@
 
-from enum import Enum, auto
+from aenum import Enum, auto
 
 
 class PropertyName(Enum):

--- a/epi_judge_python/test_framework/tri_bool.py
+++ b/epi_judge_python/test_framework/tri_bool.py
@@ -1,5 +1,5 @@
 
-from enum import Enum, auto
+from aenum import Enum, auto
 
 
 class TriBool(Enum):


### PR DESCRIPTION
This update enables people running python3 versions earlier than 3.6 to use the test framework, by using [aenum](https://pypi.org/project/aenum/) instead of [enum](https://docs.python.org/3/library/enum.html), since `auto` was only added to the the `enum` stdlib starting in version python3.6.