### PR TITLE
Fixed bug in get depth of Problem 9.4 for python #110

### DIFF
--- a/epi_judge_python_solutions/lowest_common_ancestor_with_parent.py
+++ b/epi_judge_python_solutions/lowest_common_ancestor_with_parent.py
@@ -12,7 +12,7 @@ def lca(node0: BinaryTreeNode,
         node1: BinaryTreeNode) -> Optional[BinaryTreeNode]:
     def get_depth(node):
         depth = 0
-        while node:
+        while node.parent:
             depth += 1
             node = node.parent
         return depth


### PR DESCRIPTION
Fix for bug in get_depth for Problem 9.4 for python #110 where node.parent should be used in the while loop condition

```
$ python3.7 epi_judge_python_solutions/lowest_common_ancestor_with_parent.py 
Test PASSED (948/948) [   3 us]
Time complexity: O(log(size(tree))+height(tree)+log(node1))
Average running time:    4 us
Median running time:     3 us
*** You've passed ALL tests. Congratulations! ***
```

