### PR TITLE
remove redundant fast.next.next check

### DIFF
--- a/epi_judge_python_solutions/is_list_cyclic.py
+++ b/epi_judge_python_solutions/is_list_cyclic.py
@@ -15,7 +15,7 @@ def has_cycle(head):
                 return step
 
     fast = slow = head
-    while fast and fast.next and fast.next.next:
+    while fast and fast.next:
         slow, fast = slow.next, fast.next.next
         if slow is fast:
             # Finds the start of the cycle.


### PR DESCRIPTION
It seems that the fast.next.next check is redundant for is_list_cyclic.py