### PR TITLE
Fixed comment for Problem 24.17 and updated return statement to return from helper function call #127

### DIFF
--- a/epi_judge_python_solutions/kth_largest_element_in_long_array.py
+++ b/epi_judge_python_solutions/kth_largest_element_in_long_array.py
@@ -11,14 +11,13 @@ def find_kth_largest_unknown_length(stream: Iterator[int], k: int) -> int:
     for x in stream:
         candidates.append(x)
         if len(candidates) >= 2 * k - 1:
-            # Reorders elements about median with larger elements appearing
-            # before the median.
+            # Reorders elements about the kth largest element with
+            # larger elements appearing before it.
             find_kth_largest(k, candidates)
             # Resize to keep just the k largest elements seen so far.
             del candidates[k:]
     # Finds the k-th largest element in candidates.
-    find_kth_largest(k, candidates)
-    return candidates[k - 1]
+    return find_kth_largest(k, candidates)
 
 
 # Pythonic solution that uses library method but costs O(nlogk) time.


### PR DESCRIPTION
1. Fixed comment for Problem 24.17 and updated return statement to return from helper function call #127 to refer to the kth largest element instead of median.
2. Fixed return statement to return from helper function call  instead of calling the helper function and returning an element from the candidates list

```
$ python3.7 epi_judge_python_solutions/kth_largest_element_in_long_array.py 
Test PASSED (503/503) [  24 ms]
Average running time:  242 us
Median running time:    42 us
*** You've passed ALL tests. Congratulations! ***
```