### PR TITLE
Minor: Change method signature in accordance with test

### DIFF
--- a/epi_judge_python/tree_from_preorder_inorder.py
+++ b/epi_judge_python/tree_from_preorder_inorder.py
@@ -1,11 +1,11 @@
-from typing import List
+from typing import List, Optional
 
 from binary_tree_node import BinaryTreeNode
 from test_framework import generic_test
 
 
 def binary_tree_from_preorder_inorder(preorder: List[int],
-                                      inorder: List[int]) -> BinaryTreeNode:
+                                      inorder: List[int]) -> Optional[BinaryTreeNode]:
     # TODO - you fill in here.
     return BinaryTreeNode()
 

--- a/epi_judge_python_solutions/tree_from_preorder_inorder.py
+++ b/epi_judge_python_solutions/tree_from_preorder_inorder.py
@@ -1,11 +1,11 @@
-from typing import List
+from typing import List, Optional
 
 from binary_tree_node import BinaryTreeNode
 from test_framework import generic_test
 
 
 def binary_tree_from_preorder_inorder(preorder: List[int],
-                                      inorder: List[int]) -> BinaryTreeNode:
+                                      inorder: List[int]) -> Optional[BinaryTreeNode]:
 
     node_to_inorder_idx = {data: i for i, data in enumerate(inorder)}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/830963/74733003-54f74880-5243-11ea-80d1-9daaa70ba27d.png)
There is a test that strictly enforce the return to be None, but the signature requires the method to return always a BinaryTreeNode.

Since you're already making use of `typing` I wanted to highlight that [you could use Optional](https://docs.python.org/3/library/typing.html#typing.Optional) that exactly covers this use case, imho.
> Optional[X] is equivalent to Union[X, None].