### PR TITLE
Expose progress website and sources in gitlab pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+image: alpine:latest
+
+pages:
+  stage: deploy
+  script:
+  - mkdir public
+  - cp index.html public/
+  - cp -r epi_judge_python/ public/
+  - cp -r html/ public/
+  - cp problem_mapping.js public/
+  artifacts:
+    paths:
+    - public
+  only:
+  - master


### PR DESCRIPTION
Hello, this yaml file provide the ability for any user to statically display their own website with the progress and get it updated automatically through ci.
For example, see https://abuggin.gitlab.io/epi-judge/
