### PR TITLE
Improvement: Add more checks to longest increasing subarray test

### DIFF
--- a/epi_judge_java/epi/LongestIncreasingSubarray.java
+++ b/epi_judge_java/epi/LongestIncreasingSubarray.java
@@ -1,6 +1,7 @@
 package epi;
 import epi.test_framework.EpiTest;
 import epi.test_framework.GenericTest;
+import epi.test_framework.TestFailure;
 
 import java.util.List;
 public class LongestIncreasingSubarray {
@@ -20,9 +21,26 @@ public class LongestIncreasingSubarray {
     // TODO - you fill in here.
     return new Subarray(0, 0);
   }
+
   @EpiTest(testDataFile = "longest_increasing_subarray.tsv")
-  public static int findLongestIncreasingSubarrayWrapper(List<Integer> A) {
+  public static int findLongestIncreasingSubarrayWrapper(List<Integer> A)
+      throws Exception {
     Subarray result = findLongestIncreasingSubarray(A);
+
+    if (result.start < 0 || result.start >= A.size() ||
+      result.end < 0 || result.end >= A.size() ||
+      result.start > result.end)
+      throw new TestFailure("Index out of range");
+
+    for (int i = result.start + 1; i < result.end; ++i) {
+      if (A.get(i) <= A.get(i - 1)) {
+      throw new TestFailure()
+          .withMismatchInfo(
+              i, String.format("A[%d] < A[%d]", i - 1, i),
+              String.format("%d >= %d", A.get(i - 1), A.get(i)));
+      }
+    }
+
     return result.end - result.start + 1;
   }
 

--- a/epi_judge_java_solutions/epi/LongestIncreasingSubarray.java
+++ b/epi_judge_java_solutions/epi/LongestIncreasingSubarray.java
@@ -2,6 +2,7 @@ package epi;
 
 import epi.test_framework.EpiTest;
 import epi.test_framework.GenericTest;
+import epi.test_framework.TestFailure;
 
 import java.util.List;
 
@@ -48,8 +49,24 @@ public class LongestIncreasingSubarray {
   }
 
   @EpiTest(testDataFile = "longest_increasing_subarray.tsv")
-  public static int findLongestIncreasingSubarrayWrapper(List<Integer> A) {
+  public static int findLongestIncreasingSubarrayWrapper(List<Integer> A)
+      throws Exception {
     Subarray result = findLongestIncreasingSubarray(A);
+
+    if (result.start < 0 || result.start >= A.size() ||
+      result.end < 0 || result.end >= A.size() ||
+      result.start > result.end)
+      throw new TestFailure("Index out of range");
+
+    for (int i = result.start + 1; i < result.end; ++i) {
+      if (A.get(i) <= A.get(i - 1)) {
+      throw new TestFailure()
+          .withMismatchInfo(
+              i, String.format("A[%d] < A[%d]", i - 1, i),
+              String.format("%d >= %d", A.get(i - 1), A.get(i)));
+      }
+    }
+
     return result.end - result.start + 1;
   }
 


### PR DESCRIPTION
This PR proposes more tests for the "longest increasing subarray". Currently only the length of the subarray is checked. The suggested changes add more checks:
- checks if the result object is valid
- checks if the subarray is increasing

_Context: while working on https://github.com/stefantds/go-epi-judge I got to look at some Java test code a bit closer. I've found some small potential improvements. I am opening a separate PR for each. Please have a look if there is something that can be improved._