### PR TITLE
Improvement: Reuse result of binomial coefficients call

### DIFF
--- a/epi_judge_java/epi/OfflineSampling.java
+++ b/epi_judge_java/epi/OfflineSampling.java
@@ -28,8 +28,7 @@ public class OfflineSampling {
         RandomSequenceChecker.binomialCoefficient(A.size(), k);
     Collections.sort(A);
     List<List<Integer>> combinations = new ArrayList<>();
-    for (int i = 0; i < RandomSequenceChecker.binomialCoefficient(A.size(), k);
-         ++i) {
+    for (int i = 0; i < totalPossibleOutcomes; ++i) {
       combinations.add(
           RandomSequenceChecker.computeCombinationIdx(A, A.size(), k, i));
     }

--- a/epi_judge_java/epi/OnlineSampling.java
+++ b/epi_judge_java/epi/OnlineSampling.java
@@ -32,8 +32,7 @@ public class OnlineSampling {
         RandomSequenceChecker.binomialCoefficient(A.size(), k);
     Collections.sort(A);
     List<List<Integer>> combinations = new ArrayList<>();
-    for (int i = 0; i < RandomSequenceChecker.binomialCoefficient(A.size(), k);
-         ++i) {
+    for (int i = 0; i < totalPossibleOutcomes; ++i) {
       combinations.add(
           RandomSequenceChecker.computeCombinationIdx(A, A.size(), k, i));
     }

--- a/epi_judge_java/epi/RandomSubset.java
+++ b/epi_judge_java/epi/RandomSubset.java
@@ -31,7 +31,7 @@ public class RandomSubset {
       A.add(i);
     }
     List<List<Integer>> combinations = new ArrayList<>();
-    for (int i = 0; i < RandomSequenceChecker.binomialCoefficient(n, k); ++i) {
+    for (int i = 0; i < totalPossibleOutcomes; ++i) {
       combinations.add(RandomSequenceChecker.computeCombinationIdx(A, n, k, i));
     }
     List<Integer> sequence = new ArrayList<>();

--- a/epi_judge_java_solutions/epi/OfflineSampling.java
+++ b/epi_judge_java_solutions/epi/OfflineSampling.java
@@ -37,8 +37,7 @@ public class OfflineSampling {
         RandomSequenceChecker.binomialCoefficient(A.size(), k);
     Collections.sort(A);
     List<List<Integer>> combinations = new ArrayList<>();
-    for (int i = 0; i < RandomSequenceChecker.binomialCoefficient(A.size(), k);
-         ++i) {
+    for (int i = 0; i < totalPossibleOutcomes; ++i) {
       combinations.add(
           RandomSequenceChecker.computeCombinationIdx(A, A.size(), k, i));
     }

--- a/epi_judge_java_solutions/epi/OnlineSampling.java
+++ b/epi_judge_java_solutions/epi/OnlineSampling.java
@@ -55,8 +55,7 @@ public class OnlineSampling {
         RandomSequenceChecker.binomialCoefficient(A.size(), k);
     Collections.sort(A);
     List<List<Integer>> combinations = new ArrayList<>();
-    for (int i = 0; i < RandomSequenceChecker.binomialCoefficient(A.size(), k);
-         ++i) {
+    for (int i = 0; i < totalPossibleOutcomes; ++i) {
       combinations.add(
           RandomSequenceChecker.computeCombinationIdx(A, A.size(), k, i));
     }

--- a/epi_judge_java_solutions/epi/RandomSubset.java
+++ b/epi_judge_java_solutions/epi/RandomSubset.java
@@ -63,7 +63,7 @@ public class RandomSubset {
       A.add(i);
     }
     List<List<Integer>> combinations = new ArrayList<>();
-    for (int i = 0; i < RandomSequenceChecker.binomialCoefficient(n, k); ++i) {
+    for (int i = 0; i < totalPossibleOutcomes; ++i) {
       combinations.add(RandomSequenceChecker.computeCombinationIdx(A, n, k, i));
     }
     List<Integer> sequence = new ArrayList<>();


### PR DESCRIPTION
This is a minor improvement for three tests ("offline sampling", "online sampling" and "random subset"). Although it doesn't make a big difference, one could reuse the already calculated value `totalPossibleOutcomes `. This avoids one unnecessary function call and improves slightly the readability of the code.

_Context: while working on https://github.com/stefantds/go-epi-judge I got to look at some Java test code a bit closer. I've found some small potential improvements. I am opening a separate PR for each. Please have a look if there is something that can be improved._