### PR TITLE
Fix: Typo in queue operation

### DIFF
--- a/epi_judge_java/epi/QueueFromStacks.java
+++ b/epi_judge_java/epi/QueueFromStacks.java
@@ -36,7 +36,7 @@ public class QueueFromStacks {
 
       for (QueueOp op : ops) {
         switch (op.op) {
-        case "QueueWithMax":
+        case "Queue":
           q = new Queue();
           break;
         case "enqueue":

--- a/epi_judge_java_solutions/epi/QueueFromStacks.java
+++ b/epi_judge_java_solutions/epi/QueueFromStacks.java
@@ -49,7 +49,7 @@ public class QueueFromStacks {
 
       for (QueueOp op : ops) {
         switch (op.op) {
-        case "QueueWithMax":
+        case "Queue":
           q = new Queue();
           break;
         case "enqueue":


### PR DESCRIPTION
This is a small typo fix: the operation for creating a new queue object in the test file is called here `Queue`, not `QueueWithMax` (probably a copy problem from the queue with max problem). However, in practice this doesn't affect the test as the test cases don't create multiple queues per test case and one queue is correctly instantiated in line 35. However, it might cause issues in the future when more test cases are introduced.

_Context: while working on https://github.com/stefantds/go-epi-judge I got to look at some Java test code a bit closer. I've found some small potential improvements. I am opening a separate PR for each. Please have a look if there is something that can be improved._