### PR TITLE
Fix: Don't sort permutations

### DIFF
--- a/epi_judge_java/epi/Permutations.java
+++ b/epi_judge_java/epi/Permutations.java
@@ -19,13 +19,7 @@ public class Permutations {
     if (result == null) {
       return false;
     }
-    for (List<Integer> l : expected) {
-      Collections.sort(l);
-    }
     expected.sort(new LexicographicalListComparator<>());
-    for (List<Integer> l : result) {
-      Collections.sort(l);
-    }
     result.sort(new LexicographicalListComparator<>());
     return expected.equals(result);
   }

--- a/epi_judge_java_solutions/epi/Permutations.java
+++ b/epi_judge_java_solutions/epi/Permutations.java
@@ -41,13 +41,7 @@ public class Permutations {
     if (result == null) {
       return false;
     }
-    for (List<Integer> l : expected) {
-      Collections.sort(l);
-    }
     expected.sort(new LexicographicalListComparator<>());
-    for (List<Integer> l : result) {
-      Collections.sort(l);
-    }
     result.sort(new LexicographicalListComparator<>());
     return expected.equals(result);
   }


### PR DESCRIPTION
We have here a list of permutations. When comparing the actual and the expected result, the different permutations should not be sorted, as that "breaks" the permutations.

_Context: while working on https://github.com/stefantds/go-epi-judge I got to look at some Java test code a bit closer. I've found some small potential improvements. I am opening a separate PR for each. Please have a look if there is something that can be improved._