### PR TITLE
Fix: checks for smallest subarray covering all values

### DIFF
--- a/epi_judge_java/epi/SmallestSubarrayCoveringAllValues.java
+++ b/epi_judge_java/epi/SmallestSubarrayCoveringAllValues.java
@@ -35,14 +35,14 @@ public class SmallestSubarrayCoveringAllValues {
     if (result.start < 0) {
       throw new TestFailure("Subarray start index is negative");
     }
+    if (result.end >= paragraph.size()) {
+      throw new TestFailure("Subarray end index exceeds array size");
+    }
     int paraIdx = result.start;
 
     while (kwIdx < keywords.size()) {
-      if (paraIdx >= paragraph.size()) {
+      if (paraIdx > result.end) {
         throw new TestFailure("Not all keywords are in the generated subarray");
-      }
-      if (paraIdx >= paragraph.size()) {
-        throw new TestFailure("Subarray end index exceeds array size");
       }
       if (paragraph.get(paraIdx).equals(keywords.get(kwIdx))) {
         kwIdx++;

--- a/epi_judge_java_solutions/epi/SmallestSubarrayCoveringAllValues.java
+++ b/epi_judge_java_solutions/epi/SmallestSubarrayCoveringAllValues.java
@@ -90,14 +90,14 @@ public class SmallestSubarrayCoveringAllValues {
     if (result.start < 0) {
       throw new TestFailure("Subarray start index is negative");
     }
+    if (result.end >= paragraph.size()) {
+      throw new TestFailure("Subarray end index exceeds array size");
+    }
     int paraIdx = result.start;
 
     while (kwIdx < keywords.size()) {
-      if (paraIdx >= paragraph.size()) {
+      if (paraIdx > result.end) {
         throw new TestFailure("Not all keywords are in the generated subarray");
-      }
-      if (paraIdx >= paragraph.size()) {
-        throw new TestFailure("Subarray end index exceeds array size");
       }
       if (paragraph.get(paraIdx).equals(keywords.get(kwIdx))) {
         kwIdx++;


### PR DESCRIPTION
I might be missing something, but in my understanding the checks and the failure message here are incorrect. The PR proposes a possible way to fix this.

_Context: while working on https://github.com/stefantds/go-epi-judge I got to look at some Java test code a bit closer. I've found some small potential improvements. I am opening a separate PR for each. Please have a look if there is something that can be improved._