### PR TITLE
Fix: Ignore order on task pairing checks

### DIFF
--- a/epi_judge_java/epi/TaskPairing.java
+++ b/epi_judge_java/epi/TaskPairing.java
@@ -2,8 +2,11 @@ package epi;
 import epi.test_framework.EpiTest;
 import epi.test_framework.EpiUserType;
 import epi.test_framework.GenericTest;
+import epi.test_framework.EpiTestComparator;
 
 import java.util.List;
+import java.util.Comparator;
+
 public class TaskPairing {
   @EpiUserType(ctorParams = {Integer.class, Integer.class})
 
@@ -27,12 +30,38 @@ public class TaskPairing {
 
       PairedTasks that = (PairedTasks)o;
 
-      return task1.equals(that.task1) && task2.equals(that.task2);
+      return task1.equals(that.task1) && task2.equals(that.task2) ||
+        task1.equals(that.task2) && task2.equals(that.task1);
     }
 
     @Override
     public String toString() {
       return "[" + task1 + ", " + task2 + "]";
+    }
+  }
+
+  private static class PairedTasksComparator implements Comparator<PairedTasks> {
+    @Override
+    public int compare(PairedTasks p1, PairedTasks p2) {
+      if (p1 == null) {
+        return p2 == null ? 0 : -1;
+      }
+
+      if (p1.equals(p2)) {
+        return 0;
+      }
+
+      Integer minP1 = Math.min(p1.task1, p1.task2);
+      Integer minP2 = Math.min(p2.task1, p2.task2);
+      int minCompare = minP1.compareTo(minP2);
+
+      if (minCompare != 0) {
+        return minCompare;
+      } else {
+        Integer maxP1 = Math.max(p1.task1, p1.task2);
+        Integer maxP2 = Math.max(p2.task1, p2.task2);
+        return maxP1.compareTo(maxP2);
+      }
     }
   }
 
@@ -42,6 +71,16 @@ public class TaskPairing {
   optimumTaskAssignment(List<Integer> taskDurations) {
     // TODO - you fill in here.
     return null;
+  }
+
+  @EpiTestComparator
+  public static boolean comp(List<PairedTasks> expected, List<PairedTasks> result) {
+    if (result == null) {
+      return false;
+    }
+    result.sort(new PairedTasksComparator());
+    expected.sort(new PairedTasksComparator());
+    return expected.equals(result);
   }
 
   public static void main(String[] args) {

--- a/epi_judge_java_solutions/epi/TaskPairing.java
+++ b/epi_judge_java_solutions/epi/TaskPairing.java
@@ -3,9 +3,11 @@ package epi;
 import epi.test_framework.EpiTest;
 import epi.test_framework.EpiUserType;
 import epi.test_framework.GenericTest;
+import epi.test_framework.EpiTestComparator;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class TaskPairing {
@@ -31,12 +33,38 @@ public class TaskPairing {
 
       PairedTasks that = (PairedTasks)o;
 
-      return task1.equals(that.task1) && task2.equals(that.task2);
+      return task1.equals(that.task1) && task2.equals(that.task2) ||
+        task1.equals(that.task2) && task2.equals(that.task1);
     }
 
     @Override
     public String toString() {
       return "[" + task1 + ", " + task2 + "]";
+    }
+  }
+
+  private static class PairedTasksComparator implements Comparator<PairedTasks> {
+    @Override
+    public int compare(PairedTasks p1, PairedTasks p2) {
+      if (p1 == null) {
+        return p2 == null ? 0 : -1;
+      }
+
+      if (p1.equals(p2)) {
+        return 0;
+      }
+
+      Integer minP1 = Math.min(p1.task1, p1.task2);
+      Integer minP2 = Math.min(p2.task1, p2.task2);
+      int minCompare = minP1.compareTo(minP2);
+
+      if (minCompare != 0) {
+        return minCompare;
+      } else {
+        Integer maxP1 = Math.max(p1.task1, p1.task2);
+        Integer maxP2 = Math.max(p2.task1, p2.task2);
+        return maxP1.compareTo(maxP2);
+      }
     }
   }
 
@@ -52,6 +80,16 @@ public class TaskPairing {
           new PairedTasks(taskDurations.get(i), taskDurations.get(j)));
     }
     return optimumAssignments;
+  }
+
+  @EpiTestComparator
+  public static boolean comp(List<PairedTasks> expected, List<PairedTasks> result) {
+    if (result == null) {
+      return false;
+    }
+    result.sort(new PairedTasksComparator());
+    expected.sort(new PairedTasksComparator());
+    return expected.equals(result);
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
In problem 17.01, the problem statement doesn't mention any particular order of the output. Currently the test only accepts the given order in the test file. 
My personal understanding of the problem statement is that the task assignment should 
- also accept a different order of assignments: e.g. `[(0, 1), (2, 3)]` and `[(2, 3), (0, 1)]` should be equivalent
- task 1 and task 2 should be interchangeable: e.g. `(0,1)` and `(1,0)` should be equivalent

The proposed fix implements a way to achieve the above-mentioned fixes.

_Context: while working on https://github.com/stefantds/go-epi-judge I got to look at some Java test code a bit closer. I've found some small potential improvements. I am opening a separate PR for each. Please have a look if there is something that can be improved._