### PR TITLE
Fix run count_inversions.exe C++ test failure with MSVC

### DIFF
--- a/epi_judge_cpp_solutions/count_inversions.cc
+++ b/epi_judge_cpp_solutions/count_inversions.cc
@@ -19,9 +19,11 @@ int CountSubarrayInversions(int start, int finish, vector<int>* A_ptr) {
   }
 
   int mid = start + ((finish - start) / 2);
-  return CountSubarrayInversions(start, mid, A_ptr) +
-         CountSubarrayInversions(mid, finish, A_ptr) +
-         MergeSortAndCountInversionsAcrossSubarrays(start, mid, finish, A_ptr);
+  int res = CountSubarrayInversions(start, mid, A_ptr);
+  res += CountSubarrayInversions(mid, finish, A_ptr);
+  res += MergeSortAndCountInversionsAcrossSubarrays(start, mid, finish, A_ptr);
+
+  return res;
 }
 
 // Merge two sorted subarrays A[start, mid - 1] and A[mid, finish - 1] into


### PR DESCRIPTION
1. EPIJudge failed to run C++ test 'count_inversions.exe' with MSVC on windows. 
2. Open a source issue ticket [https://github.com/adnanaziz/EPIJudge/issues/220](https://github.com/adnanaziz/EPIJudge/issues/220) to track it.
3. Make this PR to fix this test issue with MSVC on windows. 