### PR TITLE
Python EPI: Only print stdout on failures

### DIFF
--- a/epi_judge_python/test_framework/generic_test.py
+++ b/epi_judge_python/test_framework/generic_test.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import sys
@@ -82,8 +83,9 @@ def run_tests(handler, config, res_printer):
         test_failure = TestFailure()
 
         try:
+            test_stdout = io.StringIO()
             test_output = handler.run_test(config.timeout_seconds,
-                                           config.metrics_override, test_case)
+                                           config.metrics_override, test_case, test_stdout)
             result = TestResult.PASSED
             tests_passed += 1
             metrics.append(test_output.metrics)
@@ -107,6 +109,7 @@ def run_tests(handler, config, res_printer):
                         test_failure.get_description(), test_output.timer)
 
         if result != TestResult.PASSED:
+            print(test_stdout.getvalue())
             if not handler.expected_is_void():
                 test_case.pop()
             if test_explanation not in ('', 'TODO'):


### PR DESCRIPTION
I recommended EPI(Judge) to a friend, and she's complained that successful testcases pollute stdout when debugging failed one. This fixes that. 

E.g., using Dutch National Flag and failing on something random (asserting array != [1])

before:
![image](https://user-images.githubusercontent.com/22038419/204051613-3dad6b26-8c33-4500-9bdf-71f9f0d32d44.png)


after: 
![image](https://user-images.githubusercontent.com/22038419/204051414-929a560d-7395-4d38-8b9e-8125a867555a.png)
