### PR TITLE
Fix missing TestFailure import in smallest_subarray_covering_all_values.py

### DIFF
--- a/epi_judge_python/smallest_subarray_covering_all_values.py
+++ b/epi_judge_python/smallest_subarray_covering_all_values.py
@@ -3,6 +3,7 @@ import functools
 from typing import List
 
 from test_framework import generic_test
+from test_framework.test_failure import TestFailure
 from test_framework.test_utils import enable_executor_hook
 
 Subarray = collections.namedtuple('Subarray', ('start', 'end'))


### PR DESCRIPTION
`TestFailure` class is not imported in this file and crashes the program