### PR TITLE
FIX: adding upcoming elements to the heap, after first `k` ones.

### DIFF
--- a/epi_judge_python_solutions/sort_almost_sorted_array.py
+++ b/epi_judge_python_solutions/sort_almost_sorted_array.py
@@ -16,7 +16,7 @@ def sort_approximately_sorted_array(sequence: Iterator[int],
 
     result = []
     # For every new element, add it to min_heap and extract the smallest.
-    for x in sequence:
+    for x in sequence[k:]:
         smallest = heapq.heappushpop(min_heap, x)
         result.append(smallest)
 


### PR DESCRIPTION
we've already added first k elements to the heap, so it's needed to read the sequence from k to the end and skip already added elements to avoid duplicate elements in result.